### PR TITLE
fix(log): 终端中的日志信息，可点击直接跳转到调用者

### DIFF
--- a/define.go
+++ b/define.go
@@ -128,3 +128,4 @@ const AdminServiceModuleName = "admin"
 
 var NodeId = ""
 var ServerModule = false
+var LoggerCallerFullPath = false // 是否启用日志调用文件全路径

--- a/log/logger.go
+++ b/log/logger.go
@@ -122,7 +122,12 @@ func initLogger() {
 		}
 		/*自定义代码路径、行号输出*/
 		customCallerEncoder = func(caller zapcore.EntryCaller, enc zapcore.PrimitiveArrayEncoder) {
-			enc.AppendString("[" + caller.TrimmedPath() + "]")
+			if tgf.LoggerCallerFullPath {
+				enc.AppendString(fmt.Sprintf("%s:%d", caller.File, caller.Line))
+			} else {
+				_, file := filepath.Split(caller.File)
+				enc.AppendString(fmt.Sprintf("%s:%d", file, caller.Line))
+			}
 		}
 		logLevel = tgf.GetStrConfig[string](tgf.EnvironmentLoggerLevel)
 		logPath  = tgf.GetStrConfig[string](tgf.EnvironmentLoggerPath)


### PR DESCRIPTION
## 起因
在终端输出的日志，**堆栈信息是可点击**，在项目开发阶段不方便快速定位问题，如下。
![615a2f504ea7a301601c6a0b8f5b6e38](https://github.com/user-attachments/assets/88b099c1-aac1-4320-b525-14aa94836a25)

## 修改后
![QQ_1727260774809](https://github.com/user-attachments/assets/8db36792-a4df-48a8-9d5a-82f48f4b5a62)

另外新增可选配置，可自定义是否输出全路径，开启输出全路径后，日志如下。
![71134d2fe367338b2eb7492bdc356a22](https://github.com/user-attachments/assets/38da7c37-798c-4157-a209-b74f0d9f7e78)
